### PR TITLE
fix: correct Ahrefs API payload encoding + MCP schema compliance

### DIFF
--- a/src/seo_mcp/backlinks.py
+++ b/src/seo_mcp/backlinks.py
@@ -178,7 +178,7 @@ def get_backlinks(signature: str, valid_until: str, domain: str) -> Optional[Lis
     
     url = "https://ahrefs.com/v4/stGetFreeBacklinksList"
     payload = {
-        "reportType": "TopBacklinks",
+        "reportType": ["TopBacklinks"],
         "signedInput": {
             "signature": signature,
             "input": {

--- a/src/seo_mcp/keywords.py
+++ b/src/seo_mcp/keywords.py
@@ -1,53 +1,38 @@
 from typing import List, Optional, Any, Dict
+import json
 
 import requests
 
 
+def _format_idea(idea: dict, label: str) -> str:
+    return json.dumps({
+        "label": label,
+        "keyword": idea.get('keyword', 'No keyword'),
+        "country": idea.get('country', '-'),
+        "difficulty": idea.get('difficultyLabel', 'Unknown'),
+        "volume": idea.get('volumeLabel', 'Unknown'),
+        "updatedAt": idea.get('updatedAt', '-')
+    })
+
+
 def format_keyword_ideas(keyword_data: Optional[List[Any]]) -> List[str]:
     if not keyword_data or len(keyword_data) < 2:
-        return ["\n❌ No valid keyword ideas retrieved"]
-    
-    data = keyword_data[1]
+        return ["No valid keyword ideas retrieved"]
 
+    data = keyword_data[1]
     result = []
-    
-    # 处理常规关键词推荐
+
     if "allIdeas" in data and "results" in data["allIdeas"]:
-        all_ideas = data["allIdeas"]["results"]
-        # total = data["allIdeas"].get("total", 0)
-        for idea in all_ideas:
-            simplified_idea = {
-                "keyword": idea.get('keyword', 'No keyword'),
-                "country": idea.get('country', '-'),
-                "difficulty": idea.get('difficultyLabel', 'Unknown'),
-                "volume": idea.get('volumeLabel', 'Unknown'),
-                "updatedAt": idea.get('updatedAt', '-')
-            }
-            result.append({
-                "label": "keyword ideas",
-                "value": simplified_idea
-            })
-    
-    # 处理问题类关键词推荐
+        for idea in data["allIdeas"]["results"]:
+            result.append(_format_idea(idea, "keyword ideas"))
+
     if "questionIdeas" in data and "results" in data["questionIdeas"]:
-        question_ideas = data["questionIdeas"]["results"]
-        # total = data["questionIdeas"].get("total", 0)
-        for idea in question_ideas:
-            simplified_idea = {
-                "keyword": idea.get('keyword', 'No keyword'),
-                "country": idea.get('country', '-'),
-                "difficulty": idea.get('difficultyLabel', 'Unknown'),
-                "volume": idea.get('volumeLabel', 'Unknown'),
-                "updatedAt": idea.get('updatedAt', '-')
-            }
-            result.append({
-                "label": "question ideas",
-                "value": simplified_idea
-            })
-    
+        for idea in data["questionIdeas"]["results"]:
+            result.append(_format_idea(idea, "question ideas"))
+
     if not result:
-        return ["\n❌ No valid keyword ideas retrieved"]
-    
+        return ["No valid keyword ideas retrieved"]
+
     return result
 
 

--- a/src/seo_mcp/keywords.py
+++ b/src/seo_mcp/keywords.py
@@ -59,9 +59,9 @@ def get_keyword_ideas(token: str, keyword: str, country: str = "us", search_engi
     payload = {
         "withQuestionIdeas": True,
         "captcha": token,
-        "searchEngine": search_engine,
+        "searchEngine": [search_engine],
         "country": country,
-        "keyword": ["Some", keyword]
+        "keyword": keyword
     }
     
     headers = {

--- a/src/seo_mcp/traffic.py
+++ b/src/seo_mcp/traffic.py
@@ -29,8 +29,8 @@ def check_traffic(token: str, domain_or_url: str, mode: Literal["subdomains", "e
     params = {
         "input": json.dumps({
             "captcha": token,
-            "country": country,
-            "protocol": "None",
+            "country": None if country == "None" else country,
+            "protocol": None,
             "mode": mode,
             "url": domain_or_url
         })


### PR DESCRIPTION
## Problem

3 of 4 Ahrefs tools (`get_backlinks_list`, `keyword_generator`, `get_traffic`) were broken. Only `keyword_difficulty` worked because it uses plain types that happen to match the API's expected format.

The root cause is that Ahrefs uses an **OCaml/ReScript-style JSON serialization** where:
- Tagged unions are array-wrapped: `["Google"]` not `"Google"`
- Option types use `null`, not the string `"None"`

Additionally, `format_keyword_ideas()` declared a return type of `List[str]` but actually returned `List[dict]`, which caused MCP output validation errors when the tool did manage to get data.

## Fixes

### 1. Payload encoding (`backlinks.py`, `keywords.py`, `traffic.py`)

| File | Field | Before (broken) | After (correct) |
|------|-------|-----------------|-----------------|
| `backlinks.py` | `reportType` | `"TopBacklinks"` | `["TopBacklinks"]` |
| `keywords.py` | `searchEngine` | `"Google"` | `["Google"]` |
| `keywords.py` | `keyword` | `["Some", keyword]` | `keyword` |
| `traffic.py` | `country` | `"None"` | `null` |
| `traffic.py` | `protocol` | `"None"` | `null` |

### 2. MCP schema compliance (`keywords.py`)

- `format_keyword_ideas()` now returns `List[str]` (JSON-serialized strings) as declared
- Extracted shared formatting into `_format_idea()` helper, removing duplicated code

## Testing

Verified all 4 tools return correct data against a live site (hskstory.com) via Claude Code MCP integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)